### PR TITLE
fixed class name to match file name

### DIFF
--- a/src/main/java/net/haesleinhuepf/clij/macro/modules/CLInfo.java
+++ b/src/main/java/net/haesleinhuepf/clij/macro/modules/CLInfo.java
@@ -15,7 +15,7 @@ import org.scijava.plugin.Plugin;
  */
 
 @Plugin(type = CLIJMacroPlugin.class, name = "CLIJ_clInfo")
-public class ClInfo extends AbstractCLIJPlugin implements CLIJMacroPlugin, CLIJOpenCLProcessor, OffersDocumentation {
+public class CLInfo extends AbstractCLIJPlugin implements CLIJMacroPlugin, CLIJOpenCLProcessor, OffersDocumentation {
 
     @Override
     public boolean executeCL() {


### PR DESCRIPTION
as mentioned in #11 

this compiles and runs the tests just fine on a 2012 Intel IvyBridge laptop using the beignet OpenCL runtime environment