### PR TITLE
Increase compatiblity with OpenCL 1.1

### DIFF
--- a/src/main/java/net/haesleinhuepf/clij/macro/modules/AffineTransform.java
+++ b/src/main/java/net/haesleinhuepf/clij/macro/modules/AffineTransform.java
@@ -125,14 +125,21 @@ public class AffineTransform extends AbstractCLIJPlugin implements CLIJMacroPlug
             }
         }
 
-        ClearCLImage input = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[0]);
-        ClearCLImage output = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[1]);
+        if (clij.getOpenCLVersion() < 1.2) {
+            ClearCLBuffer input = ((ClearCLBuffer) args[0]);
+            ClearCLBuffer output = ((ClearCLBuffer) args[1]);
 
-        boolean result = Kernels.affineTransform(clij, input, output, net.haesleinhuepf.clij.utilities.AffineTransform.matrixToFloatArray(at));
+            return Kernels.affineTransform(clij, input, output, net.haesleinhuepf.clij.utilities.AffineTransform.matrixToFloatArray(at));
+        } else {
+            ClearCLImage input = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[0]);
+            ClearCLImage output = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[1]);
 
-        Kernels.copy(clij, output, (ClearCLBuffer)args[1]);
+            boolean result = Kernels.affineTransform(clij, input, output, net.haesleinhuepf.clij.utilities.AffineTransform.matrixToFloatArray(at));
 
-        return result;
+            Kernels.copy(clij, output, (ClearCLBuffer) args[1]);
+
+            return result;
+        }
     }
 
     @Override

--- a/src/main/java/net/haesleinhuepf/clij/macro/modules/Blur2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/macro/modules/Blur2D.java
@@ -22,14 +22,18 @@ public class Blur2D extends AbstractCLIJPlugin implements CLIJMacroPlugin, CLIJO
         float sigmaY = asFloat(args[3]);
 
         if (containsCLBufferArguments()) {
-            // convert all arguments to CLImages
-            Object[] args = openCLImageArgs();
-            boolean result = Kernels.blur(clij, (ClearCLImage) (args[0]), (ClearCLImage) (args[1]), sigmaX, sigmaY, 0f);
-            // copy result back to the bufffer
-            Kernels.copy(clij, (ClearCLImage)args[1], (ClearCLBuffer)this.args[1]);
-            // cleanup
-            releaseImages(args);
-            return result;
+            if (clij.getOpenCLVersion() < 1.2) {
+                return Kernels.blur(clij, (ClearCLBuffer) (args[0]), (ClearCLBuffer) (args[1]), sigmaX, sigmaY, 0f);
+            } else {
+                // convert all arguments to CLImages
+                Object[] args = openCLImageArgs();
+                boolean result = Kernels.blur(clij, (ClearCLImage) (args[0]), (ClearCLImage) (args[1]), sigmaX, sigmaY, 0f);
+                // copy result back to the bufffer
+                Kernels.copy(clij, (ClearCLImage) args[1], (ClearCLBuffer) this.args[1]);
+                // cleanup
+                releaseImages(args);
+                return result;
+            }
         } else {
             return Kernels.blur(clij, (ClearCLImage)( args[0]), (ClearCLImage)(args[1]), sigmaX, sigmaY, 0f);
         }

--- a/src/main/java/net/haesleinhuepf/clij/macro/modules/Blur3D.java
+++ b/src/main/java/net/haesleinhuepf/clij/macro/modules/Blur3D.java
@@ -23,14 +23,18 @@ public class Blur3D extends AbstractCLIJPlugin implements CLIJMacroPlugin, CLIJO
         float sigmaZ = asFloat(args[4]);
 
         if (containsCLBufferArguments()) {
-            // convert all arguments to CLImages
-            Object[] args = openCLImageArgs();
-            boolean result = Kernels.blur(clij, (ClearCLImage) (args[0]), (ClearCLImage) (args[1]), sigmaX, sigmaY, sigmaZ);
-            // copy result back to the bufffer
-            Kernels.copy(clij, (ClearCLImage)args[1], (ClearCLBuffer)this.args[1]);
-            // cleanup
-            releaseImages(args);
-            return result;
+            if (clij.getOpenCLVersion() < 1.2) {
+                return Kernels.blur(clij, (ClearCLBuffer) (args[0]), (ClearCLBuffer) (args[1]), sigmaX, sigmaY, sigmaZ);
+            } else {
+                // convert all arguments to CLImages
+                Object[] args = openCLImageArgs();
+                boolean result = Kernels.blur(clij, (ClearCLImage) (args[0]), (ClearCLImage) (args[1]), sigmaX, sigmaY, sigmaZ);
+                // copy result back to the bufffer
+                Kernels.copy(clij, (ClearCLImage) args[1], (ClearCLBuffer) this.args[1]);
+                // cleanup
+                releaseImages(args);
+                return result;
+            }
         } else {
             return Kernels.blur(clij, (ClearCLImage)( args[0]), (ClearCLImage)(args[1]), sigmaX, sigmaY, sigmaZ);
         }

--- a/src/main/java/net/haesleinhuepf/clij/macro/modules/Blur3DSliceBySlice.java
+++ b/src/main/java/net/haesleinhuepf/clij/macro/modules/Blur3DSliceBySlice.java
@@ -26,14 +26,18 @@ public class Blur3DSliceBySlice extends AbstractCLIJPlugin implements CLIJMacroP
         int nY = sigmaToKernelSize(sigmaY);
 
         if (containsCLBufferArguments()) {
-            // convert all arguments to CLImages
-            Object[] args = openCLImageArgs();
-            boolean result = Kernels.blurSliceBySlice(clij, (ClearCLImage)( args[0]), (ClearCLImage)(args[1]), nX, nY, sigmaX, sigmaY);
-            // copy result back to the bufffer
-            Kernels.copy(clij, (ClearCLImage)args[1], (ClearCLBuffer)this.args[1]);
-            // cleanup
-            releaseImages(args);
-            return result;
+            if (clij.getOpenCLVersion() < 1.2) {
+                return Kernels.blurSliceBySlice(clij, (ClearCLBuffer) (args[0]), (ClearCLBuffer) (args[1]), nX, nY, sigmaX, sigmaY);
+            } else {
+                // convert all arguments to CLImages
+                Object[] args = openCLImageArgs();
+                boolean result = Kernels.blurSliceBySlice(clij, (ClearCLImage) (args[0]), (ClearCLImage) (args[1]), nX, nY, sigmaX, sigmaY);
+                // copy result back to the bufffer
+                Kernels.copy(clij, (ClearCLImage) args[1], (ClearCLBuffer) this.args[1]);
+                // cleanup
+                releaseImages(args);
+                return result;
+            }
         } else {
             return Kernels.blurSliceBySlice(clij, (ClearCLImage)( args[0]), (ClearCLImage)(args[1]), nX, nY, sigmaX, sigmaY);
         }

--- a/src/main/java/net/haesleinhuepf/clij/macro/modules/Rotate2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/macro/modules/Rotate2D.java
@@ -41,16 +41,23 @@ public class Rotate2D extends AbstractCLIJPlugin implements CLIJMacroPlugin, CLI
         //boolean result = Kernels.affineTransform(clij, (ClearCLBuffer)( args[0]), (ClearCLBuffer)(args[1]), AffineTransform.matrixToFloatArray(at));
         //releaseBuffers(args);
 
-        ClearCLImage input = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[0]);
-        ClearCLImage output = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[1]);
+        if (clij.getOpenCLVersion() < 1.2) {
+            ClearCLBuffer input = ((ClearCLBuffer) args[0]);
+            ClearCLBuffer output = ((ClearCLBuffer) args[1]);
 
-        boolean result = Kernels.affineTransform(clij, input, output, AffineTransform.matrixToFloatArray(at));
+            return Kernels.affineTransform(clij, input, output, AffineTransform.matrixToFloatArray(at));
 
-        Kernels.copy(clij, output, (ClearCLBuffer)args[1]);
+        } else {
+            ClearCLImage input = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[0]);
+            ClearCLImage output = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[1]);
+
+            boolean result = Kernels.affineTransform(clij, input, output, AffineTransform.matrixToFloatArray(at));
+
+            Kernels.copy(clij, output, (ClearCLBuffer) args[1]);
 
 
-        return result;
-
+            return result;
+        }
     }
 
     @Override

--- a/src/main/java/net/haesleinhuepf/clij/macro/modules/Rotate3D.java
+++ b/src/main/java/net/haesleinhuepf/clij/macro/modules/Rotate3D.java
@@ -44,16 +44,24 @@ public class Rotate3D extends AbstractCLIJPlugin implements CLIJMacroPlugin, CLI
 
         //boolean result = Kernels.affineTransform(clij, (ClearCLBuffer)( args[0]), (ClearCLBuffer)(args[1]), AffineTransform.matrixToFloatArray(at));
         //releaseBuffers(args);
-        ClearCLImage input = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[0]);
-        ClearCLImage output = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[1]);
+        if (clij.getOpenCLVersion() < 1.2) {
+            ClearCLBuffer input = ((ClearCLBuffer) args[0]);
+            ClearCLBuffer output = ((ClearCLBuffer) args[1]);
 
-        boolean result = Kernels.affineTransform(clij, input, output, AffineTransform.matrixToFloatArray(at));
+            return Kernels.affineTransform(clij, input, output, AffineTransform.matrixToFloatArray(at));
 
-        Kernels.copy(clij, output, (ClearCLBuffer)args[1]);
+        } else {
+
+            ClearCLImage input = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[0]);
+            ClearCLImage output = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[1]);
+
+            boolean result = Kernels.affineTransform(clij, input, output, AffineTransform.matrixToFloatArray(at));
+
+            Kernels.copy(clij, output, (ClearCLBuffer) args[1]);
 
 
-        return result;
-
+            return result;
+        }
     }
 
     @Override

--- a/src/main/java/net/haesleinhuepf/clij/macro/modules/Scale.java
+++ b/src/main/java/net/haesleinhuepf/clij/macro/modules/Scale.java
@@ -40,15 +40,22 @@ public class Scale extends AbstractCLIJPlugin implements CLIJMacroPlugin, CLIJOp
             at.translate(input.getWidth() / 2, input.getHeight() / 2, input.getDepth() / 2);
         }
 
-        ClearCLImage input = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[0]);
-        ClearCLImage output = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[1]);
+        if (clij.getOpenCLVersion() < 1.2) {
+            ClearCLBuffer input = ((ClearCLBuffer) args[0]);
+            ClearCLBuffer output = ((ClearCLBuffer) args[1]);
 
-        boolean result = Kernels.affineTransform(clij, input, output, AffineTransform.matrixToFloatArray(at));
+            return Kernels.affineTransform(clij, input, output, AffineTransform.matrixToFloatArray(at));
 
-        Kernels.copy(clij, output, (ClearCLBuffer)args[1]);
+        } else {
+            ClearCLImage input = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[0]);
+            ClearCLImage output = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[1]);
 
-        return result;
+            boolean result = Kernels.affineTransform(clij, input, output, AffineTransform.matrixToFloatArray(at));
 
+            Kernels.copy(clij, output, (ClearCLBuffer) args[1]);
+
+            return result;
+        }
     }
 
     @Override


### PR DESCRIPTION
bugfix: OpenCL crashed when dealing with clImages on an NVidia Quadro 4000 which only supports OpenCL 1.1