### PR TITLE
Bug fix: Several 2D functions not working (Rotation2D added)

### DIFF
--- a/src/main/java/net/haesleinhuepf/clij/macro/modules/AffineTransform.java
+++ b/src/main/java/net/haesleinhuepf/clij/macro/modules/AffineTransform.java
@@ -129,12 +129,12 @@ public class AffineTransform extends AbstractCLIJPlugin implements CLIJMacroPlug
             ClearCLBuffer input = ((ClearCLBuffer) args[0]);
             ClearCLBuffer output = ((ClearCLBuffer) args[1]);
 
-            return Kernels.affineTransform(clij, input, output, net.haesleinhuepf.clij.utilities.AffineTransform.matrixToFloatArray(at));
+            return Kernels.affineTransform3D(clij, input, output, net.haesleinhuepf.clij.utilities.AffineTransform.matrixToFloatArray(at));
         } else {
             ClearCLImage input = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[0]);
             ClearCLImage output = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[1]);
 
-            boolean result = Kernels.affineTransform(clij, input, output, net.haesleinhuepf.clij.utilities.AffineTransform.matrixToFloatArray(at));
+            boolean result = Kernels.affineTransform3D(clij, input, output, net.haesleinhuepf.clij.utilities.AffineTransform.matrixToFloatArray(at));
 
             Kernels.copy(clij, output, (ClearCLBuffer) args[1]);
 

--- a/src/main/java/net/haesleinhuepf/clij/macro/modules/Rotate2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/macro/modules/Rotate2D.java
@@ -9,7 +9,7 @@ import net.haesleinhuepf.clij.macro.CLIJMacroPlugin;
 import net.haesleinhuepf.clij.macro.CLIJOpenCLProcessor;
 import net.haesleinhuepf.clij.macro.documentation.OffersDocumentation;
 import net.haesleinhuepf.clij.utilities.AffineTransform;
-import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.realtransform.AffineTransform2D;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -22,40 +22,39 @@ public class Rotate2D extends AbstractCLIJPlugin implements CLIJMacroPlugin, CLI
 
     @Override
     public boolean executeCL() {
-        float angleZ = (float)(-asFloat(args[2]) / 180.0f * Math.PI);
+        float angle = (float)(-asFloat(args[2]) / 180.0f * Math.PI);
         boolean rotateAroundCenter = asBoolean(args[3]);
 
-        AffineTransform3D at = new AffineTransform3D();
+        AffineTransform2D at = new AffineTransform2D();
         Object[] args = openCLBufferArgs();
 
         if (rotateAroundCenter) {
             ClearCLBuffer input = (ClearCLBuffer) args[0];
-            at.translate(-input.getWidth() / 2, -input.getHeight() / 2, -input.getDepth() / 2);
+            at.translate(-input.getWidth() / 2, -input.getHeight() / 2);
         }
-        at.rotate(2, angleZ);
+        at.rotate(angle);
         if (rotateAroundCenter) {
             ClearCLBuffer input = (ClearCLBuffer) args[0];
-            at.translate(input.getWidth() / 2, input.getHeight() / 2, input.getDepth() / 2);
+            at.translate(input.getWidth() / 2, input.getHeight() / 2);
         }
 
         //boolean result = Kernels.affineTransform(clij, (ClearCLBuffer)( args[0]), (ClearCLBuffer)(args[1]), AffineTransform.matrixToFloatArray(at));
         //releaseBuffers(args);
-
         if (clij.getOpenCLVersion() < 1.2) {
             ClearCLBuffer input = ((ClearCLBuffer) args[0]);
             ClearCLBuffer output = ((ClearCLBuffer) args[1]);
 
-            return Kernels.affineTransform(clij, input, output, AffineTransform.matrixToFloatArray(at));
+            return Kernels.affineTransform2D(clij, input, output, AffineTransform.matrixToFloatArray2D(at));
 
         } else {
             ClearCLImage input = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[0]);
             ClearCLImage output = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[1]);
 
-            boolean result = Kernels.affineTransform(clij, input, output, AffineTransform.matrixToFloatArray(at));
+            boolean result = Kernels.affineTransform2D(clij, input, output, AffineTransform.matrixToFloatArray2D(at));
 
             Kernels.copy(clij, output, (ClearCLBuffer) args[1]);
-
-
+            
+            
             return result;
         }
     }

--- a/src/main/java/net/haesleinhuepf/clij/macro/modules/Rotate3D.java
+++ b/src/main/java/net/haesleinhuepf/clij/macro/modules/Rotate3D.java
@@ -48,14 +48,14 @@ public class Rotate3D extends AbstractCLIJPlugin implements CLIJMacroPlugin, CLI
             ClearCLBuffer input = ((ClearCLBuffer) args[0]);
             ClearCLBuffer output = ((ClearCLBuffer) args[1]);
 
-            return Kernels.affineTransform(clij, input, output, AffineTransform.matrixToFloatArray(at));
+            return Kernels.affineTransform3D(clij, input, output, AffineTransform.matrixToFloatArray(at));
 
         } else {
 
             ClearCLImage input = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[0]);
             ClearCLImage output = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[1]);
 
-            boolean result = Kernels.affineTransform(clij, input, output, AffineTransform.matrixToFloatArray(at));
+            boolean result = Kernels.affineTransform3D(clij, input, output, AffineTransform.matrixToFloatArray(at));
 
             Kernels.copy(clij, output, (ClearCLBuffer) args[1]);
 

--- a/src/main/java/net/haesleinhuepf/clij/macro/modules/Scale2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/macro/modules/Scale2D.java
@@ -9,7 +9,7 @@ import net.haesleinhuepf.clij.macro.CLIJMacroPlugin;
 import net.haesleinhuepf.clij.macro.CLIJOpenCLProcessor;
 import net.haesleinhuepf.clij.macro.documentation.OffersDocumentation;
 import net.haesleinhuepf.clij.utilities.AffineTransform;
-import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.realtransform.AffineTransform2D;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -18,14 +18,14 @@ import org.scijava.plugin.Plugin;
  */
 
 @Plugin(type = CLIJMacroPlugin.class, name = "CLIJ_scale")
-public class Scale extends AbstractCLIJPlugin implements CLIJMacroPlugin, CLIJOpenCLProcessor, OffersDocumentation {
+public class Scale2D extends AbstractCLIJPlugin implements CLIJMacroPlugin, CLIJOpenCLProcessor, OffersDocumentation {
 
     @Override
     public boolean executeCL() {
         float scaleFactor = asFloat(args[2]);
         boolean rotateAroundCenter = asBoolean(args[3]);
 
-        AffineTransform3D at = new AffineTransform3D();
+        AffineTransform2D at = new AffineTransform2D();
         Object[] args = openCLBufferArgs();
 
         if (rotateAroundCenter) {
@@ -44,13 +44,13 @@ public class Scale extends AbstractCLIJPlugin implements CLIJMacroPlugin, CLIJOp
             ClearCLBuffer input = ((ClearCLBuffer) args[0]);
             ClearCLBuffer output = ((ClearCLBuffer) args[1]);
 
-            return Kernels.affineTransform(clij, input, output, AffineTransform.matrixToFloatArray(at));
+            return Kernels.affineTransform2D(clij, input, output, AffineTransform.matrixToFloatArray2D(at));
 
         } else {
             ClearCLImage input = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[0]);
             ClearCLImage output = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[1]);
 
-            boolean result = Kernels.affineTransform(clij, input, output, AffineTransform.matrixToFloatArray(at));
+            boolean result = Kernels.affineTransform2D(clij, input, output, AffineTransform.matrixToFloatArray2D(at));
 
             Kernels.copy(clij, output, (ClearCLBuffer) args[1]);
 
@@ -70,6 +70,6 @@ public class Scale extends AbstractCLIJPlugin implements CLIJMacroPlugin, CLIJOp
 
     @Override
     public String getAvailableForDimensions() {
-        return "2D, 3D";
+        return "2D";
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/macro/modules/Translate2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/macro/modules/Translate2D.java
@@ -1,8 +1,10 @@
 package net.haesleinhuepf.clij.macro.modules;
 
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.clearcl.ClearCLImage;
 import net.haesleinhuepf.clij.kernels.Kernels;
 import net.haesleinhuepf.clij.macro.AbstractCLIJPlugin;
+import net.haesleinhuepf.clij.macro.CLIJHandler;
 import net.haesleinhuepf.clij.macro.CLIJMacroPlugin;
 import net.haesleinhuepf.clij.macro.CLIJOpenCLProcessor;
 import net.haesleinhuepf.clij.macro.documentation.OffersDocumentation;
@@ -28,9 +30,24 @@ public class Translate2D extends AbstractCLIJPlugin implements CLIJMacroPlugin, 
 
         at.translate(translateX, translateY, 0);
 
-        boolean result = Kernels.affineTransform(clij, (ClearCLBuffer)( args[0]), (ClearCLBuffer)(args[1]), AffineTransform.matrixToFloatArray(at));
-        releaseBuffers(args);
-        return result;
+        //boolean result = Kernels.affineTransform(clij, (ClearCLBuffer)( args[0]), (ClearCLBuffer)(args[1]), AffineTransform.matrixToFloatArray(at));
+        //releaseBuffers(args);
+        //return result;
+        if (clij.getOpenCLVersion() < 1.2) {
+            ClearCLBuffer input = ((ClearCLBuffer) args[0]);
+            ClearCLBuffer output = ((ClearCLBuffer) args[1]);
+
+            return Kernels.affineTransform3D(clij, input, output, net.haesleinhuepf.clij.utilities.AffineTransform.matrixToFloatArray(at));
+        } else {
+            ClearCLImage input = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[0]);
+            ClearCLImage output = CLIJHandler.getInstance().getChachedImageByBuffer((ClearCLBuffer) args[1]);
+
+            boolean result = Kernels.affineTransform3D(clij, input, output, net.haesleinhuepf.clij.utilities.AffineTransform.matrixToFloatArray(at));
+
+            Kernels.copy(clij, output, (ClearCLBuffer) args[1]);
+
+            return result;
+        }
     }
 
     @Override

--- a/src/main/resources/plugins.config
+++ b/src/main/resources/plugins.config
@@ -114,7 +114,8 @@ Plugins>ImageJ on GPU (CLIJ)>Transform,            "Rotate 2D image on GPU",    
 Plugins>ImageJ on GPU (CLIJ)>Transform,            "Rotate 3D image stack on GPU",                  net.haesleinhuepf.clij.macro.modules.Rotate3D
 Plugins>ImageJ on GPU (CLIJ)>Transform,            "Translate 2D image on GPU",                     net.haesleinhuepf.clij.macro.modules.Translate2D
 Plugins>ImageJ on GPU (CLIJ)>Transform,            "Translate 3D image on GPU",                     net.haesleinhuepf.clij.macro.modules.Translate3D
-Plugins>ImageJ on GPU (CLIJ)>Transform,            "Scale image on GPU",                            net.haesleinhuepf.clij.macro.modules.Scale
+Plugins>ImageJ on GPU (CLIJ)>Transform,            "Scale 2D image on GPU",                         net.haesleinhuepf.clij.macro.modules.Scale2D
+Plugins>ImageJ on GPU (CLIJ)>Transform,            "Scale 3D image on GPU",                         net.haesleinhuepf.clij.macro.modules.Scale3D
 Plugins>ImageJ on GPU (CLIJ)>Transform,            "-",                                             null
 Plugins>ImageJ on GPU (CLIJ)>Transform,            "Apply 2D vector field to image on GPU",         net.haesleinhuepf.clij.macro.modules.ApplyVectorField2D
 Plugins>ImageJ on GPU (CLIJ)>Transform,            "Apply 3D vector field to image on GPU",         net.haesleinhuepf.clij.macro.modules.ApplyVectorField3D

--- a/src/test/java/net/haesleinhuepf/clij/macro/modules/Rotate2DTest.java
+++ b/src/test/java/net/haesleinhuepf/clij/macro/modules/Rotate2DTest.java
@@ -1,0 +1,122 @@
+package net.haesleinhuepf.clij.macro.modules;
+
+import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.clearcl.ClearCLImage;
+import ij.IJ;
+import ij.ImageJ;
+import ij.ImagePlus;
+import ij.gui.WaitForUserDialog;
+import ij.plugin.Duplicator;
+import net.haesleinhuepf.clij.CLIJ;
+import net.haesleinhuepf.clij.kernels.Kernels;
+import net.haesleinhuepf.clij.test.TestUtilities;
+import net.haesleinhuepf.clij.utilities.AffineTransform;
+import net.imglib2.realtransform.AffineTransform2D;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Ignore;
+
+
+public class Rotate2DTest {
+    private final static double tolerance = 0.1;
+    private final static double angle = 45.0;
+
+    
+    @Ignore  
+    // Only as principle test
+    // Differences between rotIJ and are to big for direct pixel comparison
+    @Test
+    public void rotateLeft2d() throws InterruptedException {
+
+        CLIJ clij = CLIJ.getInstance();
+        
+        ImagePlus test2D = IJ.openImage("src/main/resources/blobs.tif");
+        IJ.run(test2D, "Invert LUT", "");
+        IJ.run(test2D, "32-bit", "");
+
+        test2D.show();
+
+        // do operation with ImageJ
+        ImagePlus rotIJ = test2D.duplicate();
+        IJ.run(rotIJ, "Rotate... ", "angle=" + angle + " interpolation=Bicubic");
+        rotIJ.show();
+
+        // do operation with OpenCL
+        ClearCLImage src = clij.convert(test2D, ClearCLImage.class);
+        ClearCLImage dst = clij.createCLImage(src);
+
+        float angleRad = (float) (-angle / 180.0 * Math.PI);
+        
+        AffineTransform2D at = new AffineTransform2D();
+        at.translate(-src.getWidth() / 2, -src.getHeight() / 2);
+        at.rotate(angleRad);
+        at.translate(src.getWidth() / 2, src.getHeight() / 2);
+        
+        Kernels.affineTransform2D(clij, src, dst, AffineTransform.matrixToFloatArray2D(at));
+     
+        ImagePlus rotCL = clij.convert(dst, ImagePlus.class);
+
+        clij.show(rotCL, "rotCL");
+        new WaitForUserDialog("wait").show();
+
+        assertTrue(TestUtilities.compareImages(rotIJ, rotCL, tolerance));
+
+        src.close();
+        dst.close();
+
+        IJ.exit();
+        clij.close();
+    }
+
+    
+    @Ignore  
+    // Problem with Buffer version.
+    // Error: passing 'float2' (vector of 2 'float' values) to parameter 
+    // of incompatible type 'int2' (vector of 2 'int' values)
+    // (Maybe due to used OpenCLVersion 1.2 and 2.0)
+    // (Buffer version are called in modules for getOpenCLVersion() < 1.2 only)
+    @Test
+    public void rotateLeft2d_Buffers() throws InterruptedException {
+
+        CLIJ clij = CLIJ.getInstance();
+        
+        ImagePlus test2D = IJ.openImage("src/main/resources/blobs.tif");
+        IJ.run(test2D, "Invert LUT", "");
+        IJ.run(test2D, "32-bit", "");
+
+        test2D.show();
+
+        // do operation with ImageJ
+        ImagePlus rotIJ = test2D.duplicate();
+        IJ.run(rotIJ, "Rotate... ", "angle=" + angle + " interpolation=Bicubic");
+        rotIJ.show();
+
+        // do operation with OpenCL
+        ClearCLBuffer src = clij.convert(test2D, ClearCLBuffer.class);
+        ClearCLBuffer dst = clij.createCLBuffer(src);
+
+        float angleRad = (float) (-angle / 180.0 * Math.PI);
+
+        AffineTransform2D at = new AffineTransform2D();
+
+        at.translate(-src.getWidth() / 2, -src.getHeight() / 2);
+        at.rotate(angleRad);
+        at.translate(src.getWidth() / 2, src.getHeight() / 2);
+        Kernels.affineTransform2D(clij, src, dst, AffineTransform.matrixToFloatArray2D(at));
+
+        ImagePlus rotCL = clij.convert(dst, ImagePlus.class);
+
+        clij.show(dst, "rotCL");
+        new WaitForUserDialog("wait").show();
+
+        assertTrue(TestUtilities.compareImages(rotIJ, rotCL, tolerance));
+
+        src.close();
+        dst.close();
+
+        IJ.exit();
+        clij.close();
+    }
+
+
+}


### PR DESCRIPTION
see Issue #32 (Rotate 2D image on GPU' not working on single plane images):
Black image when Rotate2D is applied to singel plane image.
At least Translate2D and Scale2D show same behaviour on GeForce GTX 1060 